### PR TITLE
context review

### DIFF
--- a/articles/multi-factor-authentication/end-user/microsoft-authenticator-app-faq.md
+++ b/articles/multi-factor-authentication/end-user/microsoft-authenticator-app-faq.md
@@ -100,7 +100,7 @@ Hier finden Sie eine vollständige Liste der Berechtigungen, die möglicherweise
 * **Anzeigen von Netzwerkverbindungen**: Wenn Sie über ein Microsoft-Konto verfügen, benötigt die App eine Netzwerk-/Internetverbindung.
 * **Lesen Ihres Speichers**: Diese Berechtigung ist nur notwendig, wenn Sie ein technisches Problem über die App-Einstellungen melden. Einige Informationen aus Ihrem Speicherkonto werden gesammelt, um das Problem zu diagnostizieren.
 * **Vollständiger Netzwerkzugriff**: Diese Berechtigung ist erforderlich, um Benachrichtigungen senden zu können, mit denen Sie Ihre Identität bestätigen.
-* **Bei Start automatisch starten**: Wenn Sie Ihr Telefon neu starten, stellt diese Berechtigung sicher, dass Sie weiterhin Benachrichtigungen erhalten, um Ihre Identität zu bestätigen.
+* **Bei Gerätestart automatisch starten**: Wenn Sie Ihr Telefon neu starten, stellt diese Berechtigung sicher, dass Sie weiterhin Benachrichtigungen erhalten, um Ihre Identität zu bestätigen.
 
 ### <a name="why-does-the-microsoft-authenticator-app-allow-you-to-approve-a-request-without-unlocking-the-device"></a>Warum ermöglicht die Microsoft Authenticator-App die Genehmigung einer Anforderung ohne Entsperrung des Geräts?
 


### PR DESCRIPTION
it is confusing, as "run" and "startup" are both used with the same word in the German translation. According to context, it would be better to add some information, such as "when starting your phone"