### PR TITLE
context review

### DIFF
--- a/articles/app-service/app-service-web-get-started-dotnet.md
+++ b/articles/app-service/app-service-web-get-started-dotnet.md
@@ -85,7 +85,7 @@ Daraufhin wird das Dialogfeld **App Service erstellen** geöffnet, in dem Sie al
 
 ## <a name="sign-in-to-azure"></a>Anmelden bei Azure
 
-Wählen Sie im Dialogfeld **App Service erstellen** die Option **Konto hinzufügen**, und melden Sie sich an Ihrem Azure-Abonnement an. Falls Sie bereits angemeldet sind, können Sie in der Dropdownliste das Konto mit dem gewünschten Abonnement auswählen.
+Wählen Sie im Dialogfeld **App Service erstellen** die Option **Konto hinzufügen**, und melden Sie sich mit Ihrem Azure-Abonnement an. Falls Sie bereits angemeldet sind, können Sie in der Dropdownliste das Konto mit dem gewünschten Abonnement auswählen.
 
 > [!NOTE]
 > Wenn Sie bereits angemeldet sind, wählen Sie noch nicht **Erstellen** aus.

--- a/articles/app-service/app-service-web-get-started-dotnet.md
+++ b/articles/app-service/app-service-web-get-started-dotnet.md
@@ -85,7 +85,7 @@ Daraufhin wird das Dialogfeld **App Service erstellen** geöffnet, in dem Sie al
 
 ## <a name="sign-in-to-azure"></a>Anmelden bei Azure
 
-Wählen Sie im Dialogfeld **App Service erstellen** die Option **Konto hinzufügen**, und melden Sie sich mit Ihrem Azure-Abonnement an. Falls Sie bereits angemeldet sind, können Sie in der Dropdownliste das Konto mit dem gewünschten Abonnement auswählen.
+Wählen Sie im Dialogfeld **App Service erstellen** die Option **Konto hinzufügen**, und melden Sie sich bei Ihrem Azure-Abonnement an. Falls Sie bereits angemeldet sind, können Sie in der Dropdownliste das Konto mit dem gewünschten Abonnement auswählen.
 
 > [!NOTE]
 > Wenn Sie bereits angemeldet sind, wählen Sie noch nicht **Erstellen** aus.


### PR DESCRIPTION
"sign in to..." the "to" was translated without regarding to the context. If you want to say you want to sign in with sth (i.E. any account), you should use "mit" instead of "an".