### PR TITLE
extra article 'das'

### DIFF
--- a/articles/application-insights/app-insights-api-custom-events-metrics.md
+++ b/articles/application-insights/app-insights-api-custom-events-metrics.md
@@ -41,7 +41,7 @@ Sie können den meisten dieser Telemetrieaufrufe [Eigenschaften und Metriken anf
 ## <a name="prep"></a>Vorbereitung
 Gehen Sie wie folgt vor, falls Sie noch nicht über einen Verweis auf das Application Insights SDK verfügen:
 
-* Fügen Sie Ihrem Projekt das Application Insights-SDK hinzu:
+* Fügen Sie Ihrem Projekt Application Insights-SDK hinzu:
 
   * [ASP.NET-Projekt](app-insights-asp-net.md)
   * [Java-Projekt](app-insights-java-get-started.md)


### PR DESCRIPTION
The article 'das' for this anglicism is set wrong, and sounds quite strange. (Actually, not even the English version shows to have an article before it.)