### PR TITLE
Fix typo

### DIFF
--- a/articles/storage/blobs/data-lake-storage-handle-data-using-databricks.md
+++ b/articles/storage/blobs/data-lake-storage-handle-data-using-databricks.md
@@ -87,7 +87,7 @@ Für die Vorgänge in diesem Tutorial wird ein Spark-Cluster benötigt. Führen 
 
     * Geben Sie einen Namen für den Cluster ein.
     * Erstellen Sie für diesen Artikel einen Cluster mit der Runtime **5.1**.
-    * Aktivieren Sie das Kontrollkästchen **Terminate after \_\_ minutes of inactivity** (Nach _ Minuten Inaktivität beenden). Falls der Cluster nicht verwendet wird, geben Sie an, nach wie vielen Minuten er beendet werden soll.
+    * Aktivieren Sie das Kontrollkästchen **Terminate after \_\_ minutes of inactivity** (Nach \_\_ Minuten Inaktivität beenden). Falls der Cluster nicht verwendet wird, geben Sie an, nach wie vielen Minuten er beendet werden soll.
 
 1. Klicken Sie auf **Cluster erstellen**.
 
@@ -336,7 +336,7 @@ Nach Abschluss des Tutorials können Sie den Cluster beenden. Wählen Sie hierzu
 
 ![Beenden eines Databricks-Clusters](./media/data-lake-storage-handle-data-using-databricks/terminate-databricks-cluster.png "Beenden eines Databricks-Clusters")
 
-Wenn Sie den Cluster nicht manuell beenden, wird er automatisch beendet, sofern Sie bei der Erstellung des Clusters das Kontrollkästchen **Terminate after \_\_ minutes of inactivity** (Nach __ Minuten Inaktivität beenden) aktiviert haben. In diesem Fall wird der Cluster automatisch beendet, wenn er für den angegebenen Zeitraum inaktiv war.
+Wenn Sie den Cluster nicht manuell beenden, wird er automatisch beendet, sofern Sie bei der Erstellung des Clusters das Kontrollkästchen **Terminate after \_\_ minutes of inactivity** (Nach \_\_ Minuten Inaktivität beenden) aktiviert haben. In diesem Fall wird der Cluster automatisch beendet, wenn er für den angegebenen Zeitraum inaktiv war.
 
 ## <a name="next-steps"></a>Nächste Schritte
 


### PR DESCRIPTION
Typo: __ -> `\_\_`.
In Markdown `__` is used to highlight. To simply show `__`, we must exit `\_\_`.