### PR TITLE
Fix typo

### DIFF
--- a/articles/storage/blobs/data-lake-storage-quickstart-create-databricks-account.md
+++ b/articles/storage/blobs/data-lake-storage-quickstart-create-databricks-account.md
@@ -218,7 +218,7 @@ Am Ende dieses Artikels können Sie den Cluster beenden. Klicken Sie im Azure Da
 
 ![Beenden eines Databricks-Clusters](./media/data-lake-storage-quickstart-create-databricks-account/terminate-databricks-cluster.png "Beenden eines Databricks-Clusters")
 
-Wenn Sie den Cluster nicht manuell beenden, wird er automatisch beendet, sofern Sie bei der Erstellung des Clusters das Kontrollkästchen **Terminate after \_\_ minutes of inactivity** (Nach __ Minuten Inaktivität beenden) aktiviert haben. Bei Verwendung dieser Option wird der Cluster beendet, wenn er für den angegebenen Zeitraum inaktiv war.
+Wenn Sie den Cluster nicht manuell beenden, wird er automatisch beendet, sofern Sie bei der Erstellung des Clusters das Kontrollkästchen **Terminate after \_\_ minutes of inactivity** (Nach \_\_ Minuten Inaktivität beenden) aktiviert haben. Bei Verwendung dieser Option wird der Cluster beendet, wenn er für den angegebenen Zeitraum inaktiv war.
 
 ## <a name="next-steps"></a>Nächste Schritte
 


### PR DESCRIPTION
Typo: `__` -> `\_\_`.
In Markdown `__` is used to highlight. To simply show `__`, we must exit `\_\_`.