### PR TITLE
Correct translation for distributions

### DIFF
--- a/articles/virtual-machines/linux/attach-disk-portal.md
+++ b/articles/virtual-machines/linux/attach-disk-portal.md
@@ -226,7 +226,7 @@ UUID=33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext4   defaults,nofail 
 ```
 Speichern Sie anschließend die Datei */etc/fstab*, und starten Sie das System neu.
 > [!NOTE]
-> Wenn Sie später einen Datenträger entfernen, ohne „fstab“ zu bearbeiten, kann der Start des virtuellen Computers fehlschlagen. Die meisten Verteilungen stellen entweder die „fstab“-Optionen *nofail* und/oder *nobootwait* zur Verfügung. Mit diesen Optionen kann ein System auch dann starten, wenn der Datenträger beim Start nicht bereitgestellt wird. Weitere Informationen zu diesen Parametern finden Sie in der Dokumentation zu Ihrer Distribution.
+> Wenn Sie später einen Datenträger entfernen, ohne „fstab“ zu bearbeiten, kann der Start des virtuellen Computers fehlschlagen. Die meisten Distributionen stellen entweder die „fstab“-Optionen *nofail* und/oder *nobootwait* zur Verfügung. Mit diesen Optionen kann ein System auch dann starten, wenn der Datenträger beim Start nicht bereitgestellt wird. Weitere Informationen zu diesen Parametern finden Sie in der Dokumentation zu Ihrer Distribution.
 > 
 > Die *nofail*-Option stellt sicher, dass der virtuelle Computer gestartet wird, selbst wenn das Dateisystem beschädigt oder der Datenträger zur Startzeit nicht vorhanden ist. Ohne diese Option können Verhalten auftreten, die unter [Cannot SSH to Linux VM due to FSTAB errors](https://blogs.msdn.microsoft.com/linuxonazure/2016/07/21/cannot-ssh-to-linux-vm-after-adding-data-disk-to-etcfstab-and-rebooting/) (Aufgrund von FSTAB-Fehler keine SSH-Verbindung mit Linux-VM möglich) beschrieben sind.
 


### PR DESCRIPTION
The German translation for a Linux distribution is Distribution (plural Distributionen). In this meaning "Verteilungen" is wrong. See e.g. https://de.wikipedia.org/wiki/Linux-Distribution
This is also correctly used in this sentence: "Den empfohlenen Ansatz finden Sie wie üblich in Ihrer Distribution".

Hilfreiche Informationen zum Einreichen eines Vorschlags:
1. Wechseln Sie zu [Quick Start Localization Style Guides (Style Guides für die Lokalisierung – Schnellstart)](https://docs.microsoft.com/globalization/localization/styleguides), und lesen Sie die **10 wichtigsten Regeln** aus dem Style Guide von Microsoft.
2. Wechseln Sie zum [Microsoft-Sprachenportal](https://www.microsoft.com/language), um eine **standardisierte Begriffsübersetzung** für Microsoft-Produkte zu überprüfen.
