### PR TITLE
changed ResourceGroupName for powershell

### DIFF
--- a/includes/key-vault-powershell-kv-creation.md
+++ b/includes/key-vault-powershell-kv-creation.md
@@ -22,7 +22,7 @@ Verwenden Sie das Azure PowerShell-Cmdlet [New-AzKeyVault](/powershell/module/az
 - Standort: **EastUS**
 
 ```azurepowershell-interactive
-New-AzKeyVault -Name "<your-unique-keyvault-name>" -ResourceGroupName "ContosoResourceGroup" -Location "East US"
+New-AzKeyVault -Name "<your-unique-keyvault-name>" -ResourceGroupName "myResourceGroup" -Location "East US"
 ```
 
 Die Ausgabe dieses Cmdlets zeigt Eigenschaften des neu erstellten Schlüsseltresors. Beachten Sie die beiden folgenden Eigenschaften:


### PR DESCRIPTION
Noticed that the command chain in https://docs.microsoft.com/de-de/azure/key-vault/secrets/quick-create-powershell does not work because of this.

Hilfreiche Informationen zum Einreichen eines Vorschlags:
1. Wechseln Sie zu [Quick Start Localization Style Guides (Style Guides für die Lokalisierung – Schnellstart)](https://docs.microsoft.com/globalization/localization/styleguides), und lesen Sie die **10 wichtigsten Regeln** aus dem Style Guide von Microsoft.
2. Wechseln Sie zum [Microsoft-Sprachenportal](https://www.microsoft.com/language), um eine **standardisierte Begriffsübersetzung** für Microsoft-Produkte zu überprüfen.
