### PR TITLE
Correcting a rather strange translation error

### DIFF
--- a/articles/active-directory/develop/authentication-flows-app-scenarios.md
+++ b/articles/active-directory/develop/authentication-flows-app-scenarios.md
@@ -91,7 +91,7 @@ Microsoft Identity Platform unterstützt die Authentifizierung für folgende A
 
 Anwendungen verwenden die verschiedenen Authentifizierungsflows, um Benutzer anzumelden und Token für den Aufruf geschützter APIs zu beziehen.
 
-### <a name="single-page-application"></a>Einseitige Anwendung
+### <a name="single-page-application"></a>Single-Page-Anwendungen (SPAs)
 
 Viele moderne Web-Apps werden als clientseitige Single-Page-Anwendungen (SPAs) erstellt. Diese Anwendungen verwenden JavaScript oder ein Framework wie Angular, Vue und React. Diese Anwendungen werden in einem Webbrowser ausgeführt.
 


### PR DESCRIPTION
"Einseitige Anwendungen" is a word wise translation of "Single-Page-Application". However, I think, the translation to "Single-Page Anwendung" is OK.

Hilfreiche Informationen zum Einreichen eines Vorschlags:
1. Wechseln Sie zu [Quick Start Localization Style Guides (Style Guides für die Lokalisierung – Schnellstart)](https://docs.microsoft.com/globalization/localization/styleguides), und lesen Sie die **10 wichtigsten Regeln** aus dem Style Guide von Microsoft.
2. Wechseln Sie zum [Microsoft-Sprachenportal](https://www.microsoft.com/language), um eine **standardisierte Begriffsübersetzung** für Microsoft-Produkte zu überprüfen.
